### PR TITLE
Updating link for OpenCV download in dependencies

### DIFF
--- a/SpectatorView/dependencies.props
+++ b/SpectatorView/dependencies.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <!-- From: http://sourceforge.net/projects/opencvlibrary/files/opencv-win/3.1.0/opencv-3.1.0.exe/download -->
+    <!-- From: https://sourceforge.net/projects/opencvlibrary/files/opencv-win/3.2.0/opencv-3.2.0-vc14.exe/download -->
     <OpenCV_vc14>C:\OpenCV\build\x64\vc14</OpenCV_vc14>
     <!-- From: https://www.blackmagicdesign.com/support -->
     <DeckLink_inc>C:\BlackMagic\Blackmagic DeckLink SDK 10.8.3\Win\include</DeckLink_inc>


### PR DESCRIPTION
Minimum opencv version is 3.2.0.